### PR TITLE
Fix date override on /departure endpoints

### DIFF
--- a/src/services/departures.service.ts
+++ b/src/services/departures.service.ts
@@ -177,7 +177,7 @@ export default class DeparturesService extends DataAccessService {
                                 departures: {} as { [direction: string]: Departure[] }
                             };
                         }
-                        departure.departures.forEach(d => d.setFullYear(now.getFullYear(), now.getMonth(), now.getDate()));
+                        departure.departures.forEach(d => d.setUTCFullYear(now.getFullYear(), now.getMonth(), now.getDate()));
                         out[departure.line].departures[departure.direction] = departure.departures
                             .map(d => ({'scheduledAt': d.toISOString()}));
                         return out;


### PR DESCRIPTION
setFullYear() sets the date, month and year according to the local timezone, which leads departure times to shift by 1 hour when the endpoint is called during DST