### PR TITLE
Have /departures endpoints adjust UTC timestamps to DST

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -296,7 +296,7 @@ components:
       properties:
         scheduledAt:
           type: string
-          description: The scheduled time of departure
+          description: The scheduled time of departure as a UTC ISO 8601 datetime. This datetime accounts for the DST status of the transit network's timezone (meaning an 08:00 AM departure in Sarajevo (CET, DST observed) will be returned as 07:00:00.000Z in winter, but as 06:00:00.000Z during DST).
           format: date-time
           example: '2025-01-01T07:00:00.000Z'
     DeparturesAtStop:

--- a/src/util/time-utils.ts
+++ b/src/util/time-utils.ts
@@ -1,0 +1,24 @@
+const NETWORK_TZ = process.env.NETWORK_TZ;
+const SCHEDULES_OFFSET = process.env.SCHEDULES_OFFSET;
+
+function getTimezoneOffset(timezone: string) {
+    const str = new Date().toLocaleString('en', {timeZone: timezone, timeZoneName: 'longOffset'});
+    const [_, h, m] = str.match(/([+-]\d+):(\d+)$/) || [0, '+00', '00'];
+    // @ts-ignore
+    return  h * 60 + (h > 0 ? +m : -m);
+}
+
+export function getNetworkOffset() {
+    if (!NETWORK_TZ || !SCHEDULES_OFFSET) {
+        throw new Error('NETWORK_TZ or SCHEDULES_OFFSET is not defined. Please set these environment variables.');
+    }
+    return getTimezoneOffset(NETWORK_TZ) - getTimezoneOffset(SCHEDULES_OFFSET);
+}
+
+export function applyOffset(dates: Date[]): Date[] {
+    const offset = getNetworkOffset();
+    if (offset == 0) {
+        return dates;
+    }
+    return dates.map(d => new Date(d.getTime() - (offset * 60000)));
+}

--- a/test/config/it-mocks.ts
+++ b/test/config/it-mocks.ts
@@ -1,1 +1,8 @@
+import { NextFunction, Request, Response } from 'express';
+
 jest.mock('../../src/lib/db/client');
+
+jest.mock('../../src/lib/auth/auth.middleware', () => ({
+    authenticatedUser: (req: Request, res: Response, next: NextFunction) => next()
+}));
+

--- a/test/departures.integration.test.ts
+++ b/test/departures.integration.test.ts
@@ -24,123 +24,132 @@ describe('Departures API tests', () => {
         }]);
     });
 
-    it('should return 200 and all 7 departures from Business on line A in both directions when requesting GET /departures/scheduled', async () => {
-        const response = await request(app).get('/departures/scheduled?from=3&line=A');
-        expect(response.status).toBe(200);
-        const nowDate = new Date().toLocaleDateString('se-SE');
-        expect(response.body).toEqual({
-            stop: {
-                id: 3,
-                name: 'Business',
-                connections: [
-                    {
-                        'directions': [
-                            'Airport',
-                            'Main Station'
-                        ],
-                        'line': 'A',
-                        'type': 'bus'
-                    }
-                ],
-            },
-            departures: {
-                A: {
-                    type: 'bus',
-                    departures: {
-                        Airport: [
-                            {
-                                scheduledAt: nowDate + 'T03:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T05:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T07:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T09:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T11:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T13:18:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T15:18:00.000Z'
-                            }
-                        ],
-                        'Main Station': [
-                            {
-                                scheduledAt: nowDate + 'T03:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T05:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T07:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T09:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T11:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T13:40:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate + 'T15:40:00.000Z'
-                            }
-                        ]
+    it('should return 200 and all 7 departures from Business on line A in both directions when requesting GET /departures/scheduled in winter time', async () => {        jest.useFakeTimers().setSystemTime(new Date('2025-06-13T17:30:00.264+02:00'));
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-01-13T00:00:00.000+01:00'));
+            const response = await request(app).get('/departures/scheduled?from=3&line=A');
+            expect(response.status).toBe(200);
+            const nowDate = new Date().toLocaleDateString('se-SE');
+            expect(response.body).toEqual({
+                stop: {
+                    id: 3,
+                    name: 'Business',
+                    connections: [
+                        {
+                            'directions': [
+                                'Airport',
+                                'Main Station'
+                            ],
+                            'line': 'A',
+                            'type': 'bus'
+                        }
+                    ],
+                },
+                departures: {
+                    A: {
+                        type: 'bus',
+                        departures: {
+                            Airport: [
+                                {
+                                    scheduledAt: nowDate + 'T04:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T06:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T08:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T10:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T12:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T14:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T16:18:00.000Z'
+                                }
+                            ],
+                            'Main Station': [
+                                {
+                                    scheduledAt: nowDate + 'T04:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T06:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T08:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T10:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T12:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T14:40:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate + 'T16:40:00.000Z'
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        });
+            });
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
-    it('should return 200 and 4 departures from Center on line A towards Main Station after 10:00 when requesting GET /departures/scheduled', async () => {
-        const nowDate = new Date();
-        nowDate.setHours(10);
-        const response = await request(app).get(`/departures/scheduled?from=2&line=A&direction=Main%20Station&after=${nowDate.toISOString().replaceAll(':', '%3A')}`);
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({
-            stop: {
-                id: 2,
-                name: 'Center',
-                connections: [
-                    {
-                        'directions': [
-                            'Airport',
-                            'Main Station'
-                        ],
-                        'line': 'A',
-                        'type': 'bus'
-                    }
-                ]
-            },
-            departures: {
-                A: {
-                    type: 'bus',
-                    departures: {
-                        'Main Station': [
-                            {
-                                scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T09:42:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T11:42:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T13:42:00.000Z'
-                            },
-                            {
-                                scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T15:42:00.000Z'
-                            }
-                        ]
+    it('should return 200 and 4 departures from Center on line A towards Main Station after 10:00 when requesting GET /departures/scheduled in summer time', async () => {
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-06-13T10:00:00.000+02:00'));
+            const nowDate = new Date('2025-06-13T10:00:00.000+02:00');
+            const response = await request(app).get(`/departures/scheduled?from=2&line=A&direction=Main%20Station&after=${nowDate.toISOString().replaceAll(':', '%3A')}`);
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                stop: {
+                    id: 2,
+                    name: 'Center',
+                    connections: [
+                        {
+                            'directions': [
+                                'Airport',
+                                'Main Station'
+                            ],
+                            'line': 'A',
+                            'type': 'bus'
+                        }
+                    ]
+                },
+                departures: {
+                    A: {
+                        type: 'bus',
+                        departures: {
+                            'Main Station': [
+                                {
+                                    scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T09:42:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T11:42:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T13:42:00.000Z'
+                                },
+                                {
+                                    scheduledAt: nowDate.toLocaleDateString('se-SE') + 'T15:42:00.000Z'
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        });
+            });
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     it('should return 404 when requesting GET /departures/scheduled for a non-existent stop', async () => {
@@ -167,76 +176,98 @@ describe('Departures API tests', () => {
         expect(response.body).toEqual({error: 'Unable to find departures from stop with internal ID 1 on line 2 in direction of Bus Station'});
     });
 
-    it('should return 200 and the next 3 departures from Pleasant Suburb towards Main Station when requesting GET /departures/next at 08:24:45.267', async () => {
-        jest.useFakeTimers().setSystemTime(new Date('2025-06-13T08:24:45.267'));
-        const response = await request(app).get('/departures/next?from=4&direction=Main%20Station&limit=3');
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({
-            stop: {
-                id: 4,
-                name: 'Pleasant Suburb',
-                connections: [
-                    {
-                        'directions': [
-                            'Airport',
-                            'Main Station'
-                        ],
-                        'line': 'A',
-                        'type': 'bus'
-                    }
-                ]
-            },
-            departures: {
-                A: {
-                    type: 'bus',
-                    departures: {
-                        'Main Station': [
-                            {
-                                scheduledAt: '2025-06-13T07:37:00.000Z'
-                            },
-                            {
-                                scheduledAt: '2025-06-13T09:37:00.000Z'
-                            },
-                            {
-                                scheduledAt: '2025-06-13T11:37:00.000Z'
-                            }
-                        ]
+    it('should return 200 and the next 3 departures from Pleasant Suburb towards Main Station when requesting GET /departures/next at 08:24:45.267 winter time', async () => {
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-12-08T08:24:45.267+01:00'));
+            const response = await request(app).get('/departures/next?from=4&direction=Main%20Station&limit=3');
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                stop: {
+                    id: 4,
+                    name: 'Pleasant Suburb',
+                    connections: [
+                        {
+                            'directions': [
+                                'Airport',
+                                'Main Station'
+                            ],
+                            'line': 'A',
+                            'type': 'bus'
+                        }
+                    ]
+                },
+                departures: {
+                    A: {
+                        type: 'bus',
+                        departures: {
+                            'Main Station': [
+                                {
+                                    scheduledAt: '2025-12-08T08:37:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-12-08T10:37:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-12-08T12:37:00.000Z'
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        })
-        jest.useRealTimers();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
-    it('should return 200 and an empty departure list from Business towards Airport when requesting GET /departures/next at 20:40:07.967', async () => {
-        jest.useFakeTimers().setSystemTime(new Date('2025-06-13T20:40:07.967'));
-        const response = await request(app).get('/departures/next?from=3&direction=Airport');
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({
-            stop: {
-                id: 3,
-                name: 'Business',
-                connections: [
-                    {
-                        'directions': [
-                            'Airport',
-                            'Main Station'
-                        ],
-                        'line': 'A',
-                        'type': 'bus'
-                    }
-                ]
-            },
-            departures: {
-                A: {
-                    type: 'bus',
-                    departures: {
-                        'Airport': []
+    it('should return 200 and the next 5 departures for the next day from Business towards Airport when requesting GET /departures/next at 20:40:07.967 summer time', async () => {
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-06-13T20:40:07.967+02:00'));
+            const response = await request(app).get('/departures/next?from=3&direction=Airport');
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                stop: {
+                    id: 3,
+                    name: 'Business',
+                    connections: [
+                        {
+                            'directions': [
+                                'Airport',
+                                'Main Station'
+                            ],
+                            'line': 'A',
+                            'type': 'bus'
+                        }
+                    ]
+                },
+                departures: {
+                    A: {
+                        type: 'bus',
+                        departures: {
+                            'Airport': [
+                                {
+                                    scheduledAt: '2025-06-14T03:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-06-14T05:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-06-14T07:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-06-14T09:18:00.000Z'
+                                },
+                                {
+                                    scheduledAt: '2025-06-14T11:18:00.000Z'
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        })
-        jest.useRealTimers();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     it('should return 404 when requesting GET /departures/next for a non-existent stop', async () => {

--- a/test/services/departures.service.integration.test.ts
+++ b/test/services/departures.service.integration.test.ts
@@ -26,24 +26,46 @@ describe('With existing departures', () => {
     });
 
     it('should return 5 departures from Airport to Station (at 00:X1) and Ferry Terminal (and 00:X6) each (Bosnian time)', async () => {
-        const stops = await stopsService.getAllStops();
-        const departures = await departuresService.getScheduledDepartures(stops.filter(s => s.name === 'Airport')[0].id!);
-        expect(departures.stop.name).toBe('Airport');
-        expect(departures.departures['1'].departures['Station']).toBeDefined();
-        expect(departures.departures['1'].departures['Ferry Terminal']).toBeDefined();
-        expect(departures.departures['1'].departures['Station']).toHaveLength(5);
-        expect(departures.departures['1'].departures['Station'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:06', '00:16', '00:26', '00:36', '00:46']);
-        expect(departures.departures['1'].departures['Ferry Terminal'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:01', '00:11', '00:21', '00:31', '00:41']);
+         try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-07-05T09:24:37.667+01:00'));
+            const stops = await stopsService.getAllStops();
+            const departures = await departuresService.getScheduledDepartures(stops.filter(s => s.name === 'Airport')[0].id!);
+            expect(departures.stop.name).toBe('Airport');
+            expect(departures.departures['1'].departures['Station']).toBeDefined();
+            expect(departures.departures['1'].departures['Ferry Terminal']).toBeDefined();
+            expect(departures.departures['1'].departures['Station']).toHaveLength(5);
+            expect(departures.departures['1'].departures['Station'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:06', '00:16', '00:26', '00:36', '00:46']);
+            expect(departures.departures['1'].departures['Ferry Terminal'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:01', '00:11', '00:21', '00:31', '00:41']);
+        } finally {
+             jest.useRealTimers();
+         }
     });
 
-    it('should return the 00:20 and 00:30 departures when requesting the next 2 departures from Station towards Ferry Terminal', async () => {
-        jest.useFakeTimers().setSystemTime(new Date('2025-06-13T00:17:35.264'));
-        const nextDepartures = await departuresService.getNextDepartures(1, '1', 'Ferry Terminal', 2);
-        expect(nextDepartures.stop.name).toBe('Station');
-        expect(Object.keys(nextDepartures.departures)).toStrictEqual(['1']);
-        expect(Object.keys(nextDepartures.departures['1'].departures)).toStrictEqual(['Ferry Terminal']);
-        expect(nextDepartures.departures['1'].departures['Ferry Terminal']).toHaveLength(2);
-        expect(nextDepartures.departures['1'].departures['Ferry Terminal'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:20', '00:30'])
-        jest.useRealTimers();
+    it('should return the 00:20 and 00:30 departures when requesting the next 2 departures from Station towards Ferry Terminal at 00:17 winter time', async () => {
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-02-13T00:17:35.264+01:00'));
+            const nextDepartures = await departuresService.getNextDepartures(1, '1', 'Ferry Terminal', 2);
+            expect(nextDepartures.stop.name).toBe('Station');
+            expect(Object.keys(nextDepartures.departures)).toStrictEqual(['1']);
+            expect(Object.keys(nextDepartures.departures['1'].departures)).toStrictEqual(['Ferry Terminal']);
+            expect(nextDepartures.departures['1'].departures['Ferry Terminal']).toHaveLength(2);
+            expect(nextDepartures.departures['1'].departures['Ferry Terminal'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:20', '00:30'])
+         } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('should return the 00:04, 00:14 and 00:24 departures when requesting the next 3 departures from Ferry Terminal towards Station at 17:30 summer time', async () => {
+        try {
+            jest.useFakeTimers().setSystemTime(new Date('2025-06-13T17:30:00.264+02:00'));
+            const nextDepartures = await departuresService.getNextDepartures(3, '1', 'Station', 3);
+            expect(nextDepartures.stop.name).toBe('Ferry Terminal');
+            expect(Object.keys(nextDepartures.departures)).toStrictEqual(['1']);
+            expect(Object.keys(nextDepartures.departures['1'].departures)).toStrictEqual(['Station']);
+            expect(nextDepartures.departures['1'].departures['Station']).toHaveLength(3);
+            expect(nextDepartures.departures['1'].departures['Station'].map(d => new Date(d.scheduledAt).toLocaleString('bs-BA', {timeStyle: 'short'}))).toStrictEqual(['00:04', '00:14', '00:24'])
+        } finally {
+            jest.useRealTimers();
+        }
     });
 })


### PR DESCRIPTION
The /departures endpoints should always return a UTC timestamp that accurately portrays the departure, at any time of the year, without the client having to adjust the time on their side (e.g. to account for DST). In other words, if a departure is scheduled at 08:00 in a UTC+1 timezone that is subject to DST (e.g. CET), it should be returned as 07:00:00.000Z during winter time, but as 06:00:00.000Z during DST (aka summer time).